### PR TITLE
Partial credit scoring and bonuses, fixes and better output

### DIFF
--- a/c4-review/c4-review
+++ b/c4-review/c4-review
@@ -20,7 +20,7 @@ disputed_reports = set()
 BASE = 0.6 # Base for Sybil protection. Was once 0.9 but 0.6 since Oct 2022
 
 parser = argparse.ArgumentParser(prog="c4-review", formatter_class=argparse.RawTextHelpFormatter,
-                                  description="Analyzes the GitHub findings repo and provides stats. Estimates payout if you provide a handle")
+                                 description="Analyzes the GitHub findings repo and provides stats. Estimates payout if you provide a handle")
 subp = parser.add_subparsers(dest="command") # dest="command" means that we see which command was parsed
 
 base_help = f"Change base (default {BASE}) for Sybil protection"
@@ -29,12 +29,12 @@ payout = subp.add_parser("payouts", description="Find out the fraction of total 
 payout.add_argument('findings_repo', type=str)
 payout.add_argument('pot_size', type=int, nargs='?')
 payout.add_argument('-w', '--handle', type=str, nargs='?')
-payout.add_argument('-b', '--base', type=str,nargs=1, help=base_help)
+payout.add_argument('-b', '--base', type=str, nargs=1, help=base_help)
 
 findings = subp.add_parser("findings", description="Summary of findings, including duplicate counts")
 findings.add_argument('findings_repo', type=str)
 findings.add_argument('pot_size', type=int, nargs='?')
-findings.add_argument('-b', '--base', type=str,nargs=1, help=base_help)
+findings.add_argument('-b', '--base', type=str, nargs=1, help=base_help)
 
 #
 # Functions
@@ -103,7 +103,7 @@ def ppMonth(epochTime):
 
 def ppTime(epochTime):
   dt = datetime.datetime.fromtimestamp(epochTime)
-  return dt.isoformat();
+  return dt.isoformat()
 
 def isHigh(s):
   return s["severity"] == "H"
@@ -118,7 +118,7 @@ def getIssueSummary(ns):
 
   h = {}
   for r in rs:
-    id=r["reportId"]
+    id = r["reportId"]
     if not id in h:
       h[id] = { "id": id, "dups": 0, "leadFinding": "unknown", "handles": [], "severity": r["severity"], "findings": [] }
     if r["duplicateOf"] == "":
@@ -127,8 +127,8 @@ def getIssueSummary(ns):
     if not r["handle"] in h[id]["handles"]:
       h[id]["dups"] += 1
       h[id]["handles"].append(r["handle"])
-      # assumes no warden will get both a full credit and partial credit duplicate of the same finding
-      h[id]["findings"].append({"handle": r["handle"], "percentage": r["percentage"], "issueId": r["issueId"]})
+      # assumes no warden will get multiple duplicates of the same finding with different partial credit
+      h[id]["findings"].append({ "handle": r["handle"], "percentage": r["percentage"], "issueId": r["issueId"] })
 
   ## Calculate shares
   totalShares = 0.0
@@ -169,17 +169,17 @@ def payout(ns):
       if not w in ws:
         ws[w] = { "rank": 0, "handle": w }
         if ns.pot_size != None:
-          ws[w]["payout"] = 0
+          ws[w]["payout"] = 0.0
         ws[w].update({ "findings": [], "findingsCount": 0, "fraction": 0.0 })
       isLeadFinding = h[id]["leadFinding"] == w
       rec = { "findingId": finding["issueId"], "isLeadFinding": isLeadFinding }
       if not isLeadFinding:
         rec["leadFindingId"] = h[id]["githubIssueId"]
       rec.update({
-          "severity": h[id]["severity"],
-          "dups": h[id]["dups"],
-          "sliceCredit": finding["sliceCredit"],
-          "shares": finding["shares"]
+        "severity": h[id]["severity"],
+        "dups": h[id]["dups"],
+        "sliceCredit": finding["sliceCredit"],
+        "shares": finding["shares"]
       })
       ws[w]["findings"].append(rec)
       ws[w]["fraction"] += finding["fraction"]
@@ -188,8 +188,8 @@ def payout(ns):
         ws[w]["payout"] += finding["payout"]
 
   for w in ws:
-      ws[w]["findingsCount"] = len(ws[w]["findings"])
-      ws[w]["findings"].sort(key=lambda r: -r["shares"])
+    ws[w]["findingsCount"] = len(ws[w]["findings"])
+    ws[w]["findings"].sort(key=lambda r: -r["shares"])
 
   # bonuses
   gatherers, highestGathererScore = ([], 0)
@@ -224,18 +224,18 @@ def payout(ns):
     elif hunterScore == highestHunterScore:
       hunters.append(w)
 
-  bonus = 0.1 if ns.pot_size is None else ns.pot_size * 0.1
+  bonus = ns.pot_size * 0.1 if ns.pot_size != None else 0.1
   for role, winners in [("hunter", hunters), ("gatherer", gatherers)]:
     for winner in winners:
       ws[winner][f"{role}Bonus"] = bonus / len(winners)
-      if ns.pot_size is not None:
+      if ns.pot_size != None:
         ws[winner]["payout"] += bonus / len(winners)
 
   wardenSummaries = [ws[w] for w in ws if (lambda w: ns.handle == None or w == ns.handle)(w)]
-  if ns.pot_size is not None:
+  if ns.pot_size != None:
     wardenSummaries.sort(key=lambda r: -r["payout"])
   else: # should be the same
-    wardenSummaries.sort(key=lambda r: -(r.get("fraction", 0) * 0.8 + r.get("hunterBonus", 0) + r.get("gathererBonus", 0)))
+    wardenSummaries.sort(key=lambda r: -(r["fraction"] * 0.8 + r.get("hunterBonus", 0) + r.get("gathererBonus", 0)))
 
   for i in range(len(wardenSummaries)):
     wardenSummaries[i]['rank'] = i + 1
@@ -275,20 +275,19 @@ def set_base(base):
   if base != None:
     BASE = float(base[0])
   else:
-    BASE=0.9
+    BASE = 0.9
 
 set_base(ns.base)
 
 if ns.command == "payouts":
-  result=payout(ns)
+  result = payout(ns)
 elif ns.command == "findings":
-  result=findings(ns)
+  result = findings(ns)
 else:
   parser.parse_args(["--help"])
 
-
 result["note"] = ("This tool only calculates shares for Highs and Mediums. " +
-                    "It does not take into account QA reports.")
+                  "It does not take into account QA reports.")
 
 ## Prints the records as valid JSON
 print(json.dumps(result, indent=2))

--- a/c4-review/c4-review
+++ b/c4-review/c4-review
@@ -78,7 +78,7 @@ def get_records_from_gh(ns, repo):
       elif l.name.startswith("partial-"):
         percentage = int(l.name.split("-")[1])
 
-    if skip or severity is None:
+    if skip or (severity is None and duplicate_of == ""):
       continue
 
     ret.append({
@@ -118,8 +118,9 @@ def get_issue_summary(ns):
   for r in rs:
     id = r["reportId"]
     if not id in dup_sets:
-      dup_sets[id] = { "id": id, "dups": 0, "leadFinding": "unknown", "handles": [], "severity": r["severity"], "findings": [] }
+      dup_sets[id] = { "id": id, "dups": 0, "leadFinding": "unknown", "handles": [], "findings": [] }
     if r["duplicateOf"] == "":
+      dup_sets[id]["severity"] = r["severity"]
       dup_sets[id]["leadFinding"] = r["handle"]
       dup_sets[id]["githubIssueId"] = r["issueId"]
     if not r["handle"] in dup_sets[id]["handles"]:

--- a/c4-review/c4-review
+++ b/c4-review/c4-review
@@ -36,8 +36,6 @@ findings.add_argument('findings_repo', type=str)
 findings.add_argument('pot_size', type=int, nargs='?')
 findings.add_argument('-b', '--base', type=str, nargs=1, help=base_help)
 
-#
-# Functions
 
 def get_participants_from_gh(repo):
   # build issue-to-handle map
@@ -127,7 +125,7 @@ def getIssueSummary(ns):
     if not r["handle"] in h[id]["handles"]:
       h[id]["dups"] += 1
       h[id]["handles"].append(r["handle"])
-      # assumes no warden will get multiple duplicates of the same finding with different partial credit
+      # Assumes no warden will get multiple duplicates of the same finding with different partial credit
       h[id]["findings"].append({ "handle": r["handle"], "percentage": r["percentage"], "issueId": r["issueId"] })
 
   ## Calculate shares
@@ -159,8 +157,8 @@ def getIssueSummary(ns):
 
 def payout(ns):
   issueSummary = getIssueSummary(ns)
-
   h = issueSummary["issueMap"]
+
   # Summarise results for each handle
   ws = {}
   for id in h:
@@ -191,7 +189,7 @@ def payout(ns):
     ws[w]["findingsCount"] = len(ws[w]["findings"])
     ws[w]["findings"].sort(key=lambda r: -r["shares"])
 
-  # bonuses
+  # Calculate bonuses
   gatherers, highestGathererScore = ([], 0)
   hunters, highestHunterScore = ([], 0)
 
@@ -204,7 +202,7 @@ def payout(ns):
     for f in ws[w]["findings"]:
       severity_score = 10 if isHigh(f) else 3
       totalSeverityFindings = totalHighRiskFindings if isHigh(f) else totalMediumRiskFindings
-      # partial dupes only get partial credit towards the TH/TG scoring
+      # Partial dupes only get partial credit towards the TH/TG scoring
       partialWeighting = min(f["sliceCredit"], 1)
       gathererScore += severity_score / totalSeverityFindings * partialWeighting
       if f["dups"] < 5:
@@ -227,10 +225,11 @@ def payout(ns):
   bonus = ns.pot_size * 0.1 if ns.pot_size != None else 0.1
   for role, winners in [("hunter", hunters), ("gatherer", gatherers)]:
     for winner in winners:
-      ws[winner][f"{role}Bonus"] = bonus / len(winners)
+      ws[winner][f"{role}Bonus"] = round(bonus / len(winners), 2)
       if ns.pot_size != None:
         ws[winner]["payout"] += bonus / len(winners)
 
+  # Prepare and format warden summaries for output
   wardenSummaries = [ws[w] for w in ws if (lambda w: ns.handle == None or w == ns.handle)(w)]
   if ns.pot_size != None:
     wardenSummaries.sort(key=lambda r: -r["payout"])
@@ -239,20 +238,12 @@ def payout(ns):
 
   for i in range(len(wardenSummaries)):
     wardenSummaries[i]['rank'] = i + 1
-
     if ns.pot_size != None:
-      # Round payouts
       wardenSummaries[i]['payout'] = round(wardenSummaries[i]['payout'], 2)
-      if 'hunterBonus' in wardenSummaries[i]:
-        wardenSummaries[i]['hunterBonus'] = round(wardenSummaries[i]['hunterBonus'], 2)
-      if 'gathererBonus' in wardenSummaries[i]:
-        wardenSummaries[i]['gathererBonus'] = round(wardenSummaries[i]['gathererBonus'], 2)
-      
       for finding in wardenSummaries[i]['findings']:
         finding['payout'] = round(finding['payout'], 2)
 
-  rs = { "totalShares": issueSummary["totalShares"], "payouts": wardenSummaries }
-  return rs
+  return { "totalShares": issueSummary["totalShares"], "payouts": wardenSummaries }
 
 def findings(ns):
   issueSummary = getIssueSummary(ns)

--- a/c4-review/c4-review
+++ b/c4-review/c4-review
@@ -44,8 +44,8 @@ def get_participants_from_gh(repo):
 
   for content in t.tree:
     if content.path.endswith(".json"):
-      handle, issueId = content.path.split("/")[-1].replace(".json", "").rsplit("-", 1)
-      handles[issueId] = handle
+      handle, issue_id = content.path.split("/")[-1].replace(".json", "").rsplit("-", 1)
+      handles[issue_id] = handle
 
 def get_records_from_gh(ns, repo):
   issues = repo.get_issues(state="all")
@@ -56,18 +56,18 @@ def get_records_from_gh(ns, repo):
       unsatisfactory_issues.add(str(i.number))
 
   for i in issues:
-    duplicateOf = ""
-    issueId = str(i.number)
-    reportId = issueId
+    duplicate_of = ""
+    issue_id = str(i.number)
+    report_id = issue_id
     severity = None
     skip = False
     percentage = 100
 
     for l in i.labels:
       if l.name.startswith("duplicate-"):
-        duplicateOf = l.name.replace("duplicate-", "")
-        reportId = duplicateOf
-        if duplicateOf in unsatisfactory_issues:
+        duplicate_of = l.name.replace("duplicate-", "")
+        report_id = duplicate_of
+        if duplicate_of in unsatisfactory_issues:
           skip = True
       elif l.name == "2 (Med Risk)":
         severity = "M"
@@ -82,34 +82,34 @@ def get_records_from_gh(ns, repo):
       continue
 
     ret.append({
-      "issueId": issueId,
-      "reportId": reportId,
-      "duplicateOf": duplicateOf,
+      "issueId": issue_id,
+      "reportId": report_id,
+      "duplicateOf": duplicate_of,
       "severity": severity,
-      "handle": handles.get(issueId, "unknown"),
+      "handle": handles.get(issue_id, "unknown"),
       "percentage": percentage
     })
 
   return ret
 
-def ppUSD(n):
+def pp_usd(n):
   return '${:0,.2f}'.format(round(n, 2))
 
-def ppMonth(epochTime):
-  dt = datetime.datetime.fromtimestamp(epochTime)
+def pp_month(epoch_time):
+  dt = datetime.datetime.fromtimestamp(epoch_time)
   return dt.strftime("%B %Y")
 
-def ppTime(epochTime):
-  dt = datetime.datetime.fromtimestamp(epochTime)
+def pp_time(epoch_time):
+  dt = datetime.datetime.fromtimestamp(epoch_time)
   return dt.isoformat()
 
-def isHigh(s):
+def is_high(s):
   return s["severity"] == "H"
 
-def isMedium(s):
+def is_medium(s):
   return s["severity"] == "M"
 
-def getIssueSummary(ns):
+def get_issue_summary(ns):
   repo = g.get_repo(f"code-423n4/{ns.findings_repo}")
   get_participants_from_gh(repo)
   rs = get_records_from_gh(ns, repo)
@@ -129,35 +129,35 @@ def getIssueSummary(ns):
       h[id]["findings"].append({ "handle": r["handle"], "percentage": r["percentage"], "issueId": r["issueId"] })
 
   ## Calculate shares
-  totalShares = 0.0
+  total_shares = 0.0
   for key in h:
-    baseShares = 10.0 if isHigh(h[key]) else 3.0
+    base_shares = 10.0 if is_high(h[key]) else 3.0
     dups = h[key]["dups"]
-    groupShares = baseShares * BASE**(dups - 1)
+    group_shares = base_shares * BASE**(dups - 1)
 
-    totalCredit = 0.0
+    total_credit = 0.0
     for finding in h[key]["findings"]:
       if finding["handle"] == h[key]["leadFinding"]:
         finding["sliceCredit"] = 1.3
       else:
         finding["sliceCredit"] = finding["percentage"] / 100.0
-      totalCredit += finding["sliceCredit"]
+      total_credit += finding["sliceCredit"]
 
     for finding in h[key]["findings"]:
-      finding["shares"] = groupShares * (finding["sliceCredit"] / totalCredit)
-      totalShares += finding["shares"]
+      finding["shares"] = group_shares * (finding["sliceCredit"] / total_credit)
+      total_shares += finding["shares"]
 
   # A pass to calculate fractions and payouts
   for key in h:
     for finding in h[key]["findings"]:
-      finding["fraction"] = finding["shares"] / totalShares
+      finding["fraction"] = finding["shares"] / total_shares
       if ns.pot_size != None:
         finding["payout"] = finding["fraction"] * ns.pot_size * 0.8 # remove bonuses
-  return { "totalShares": totalShares, "issueMap": h }
+  return { "totalShares": total_shares, "issueMap": h }
 
 def payout(ns):
-  issueSummary = getIssueSummary(ns)
-  h = issueSummary["issueMap"]
+  issue_summary = get_issue_summary(ns)
+  h = issue_summary["issueMap"]
 
   # Summarise results for each handle
   ws = {}
@@ -169,9 +169,9 @@ def payout(ns):
         if ns.pot_size != None:
           ws[w]["payout"] = 0.0
         ws[w].update({ "findings": [], "findingsCount": 0, "fraction": 0.0 })
-      isLeadFinding = h[id]["leadFinding"] == w
-      rec = { "findingId": finding["issueId"], "isLeadFinding": isLeadFinding }
-      if not isLeadFinding:
+      is_lead_finding = h[id]["leadFinding"] == w
+      rec = { "findingId": finding["issueId"], "isLeadFinding": is_lead_finding }
+      if not is_lead_finding:
         rec["leadFindingId"] = h[id]["githubIssueId"]
       rec.update({
         "severity": h[id]["severity"],
@@ -190,36 +190,36 @@ def payout(ns):
     ws[w]["findings"].sort(key=lambda r: -r["shares"])
 
   # Calculate bonuses
-  gatherers, highestGathererScore = ([], 0)
-  hunters, highestHunterScore = ([], 0)
+  gatherers, highest_gatherer_score = ([], 0)
+  hunters, highest_hunter_score = ([], 0)
 
-  totalHighRiskFindings = sum(f["severity"] == "H" for w in ws for f in ws[w]["findings"])
-  totalMediumRiskFindings = sum(f["severity"] == "M" for w in ws for f in ws[w]["findings"])
+  total_high_risk_findings = sum(f["severity"] == "H" for w in ws for f in ws[w]["findings"])
+  total_medium_risk_findings = sum(f["severity"] == "M" for w in ws for f in ws[w]["findings"])
 
   for w in ws:
-    gathererScore = 0
-    hunterScore = 0
+    gatherer_score = 0
+    hunter_score = 0
     for f in ws[w]["findings"]:
-      severity_score = 10 if isHigh(f) else 3
-      totalSeverityFindings = totalHighRiskFindings if isHigh(f) else totalMediumRiskFindings
+      severity_score = 10 if is_high(f) else 3
+      total_severity_findings = total_high_risk_findings if is_high(f) else total_medium_risk_findings
       # Partial dupes only get partial credit towards the TH/TG scoring
-      partialWeighting = min(f["sliceCredit"], 1)
-      gathererScore += severity_score / totalSeverityFindings * partialWeighting
+      partial_weighting = min(f["sliceCredit"], 1)
+      gatherer_score += severity_score / total_severity_findings * partial_weighting
       if f["dups"] < 5:
-        hunterScore += severity_score / f["dups"] * partialWeighting
+        hunter_score += severity_score / f["dups"] * partial_weighting
 
-    ws[w]["gathererScore"] = gathererScore
-    if gathererScore > highestGathererScore:
-      highestGathererScore = gathererScore
+    ws[w]["gathererScore"] = gatherer_score
+    if gatherer_score > highest_gatherer_score:
+      highest_gatherer_score = gatherer_score
       gatherers = [w]
-    elif gathererScore == highestGathererScore:
+    elif gatherer_score == highest_gatherer_score:
       gatherers.append(w)
 
-    ws[w]["hunterScore"] = hunterScore
-    if hunterScore > highestHunterScore:
-      highestHunterScore = hunterScore
+    ws[w]["hunterScore"] = hunter_score
+    if hunter_score > highest_hunter_score:
+      highest_hunter_score = hunter_score
       hunters = [w]
-    elif hunterScore == highestHunterScore:
+    elif hunter_score == highest_hunter_score:
       hunters.append(w)
 
   bonus = ns.pot_size * 0.1 if ns.pot_size != None else 0.1
@@ -230,30 +230,30 @@ def payout(ns):
         ws[winner]["payout"] += bonus / len(winners)
 
   # Prepare and format warden summaries for output
-  wardenSummaries = [ws[w] for w in ws if (lambda w: ns.handle == None or w == ns.handle)(w)]
+  warden_summaries = [ws[w] for w in ws if (lambda w: ns.handle == None or w == ns.handle)(w)]
   if ns.pot_size != None:
-    wardenSummaries.sort(key=lambda r: -r["payout"])
+    warden_summaries.sort(key=lambda r: -r["payout"])
   else: # should be the same
-    wardenSummaries.sort(key=lambda r: -(r["fraction"] * 0.8 + r.get("hunterBonus", 0) + r.get("gathererBonus", 0)))
+    warden_summaries.sort(key=lambda r: -(r["fraction"] * 0.8 + r.get("hunterBonus", 0) + r.get("gathererBonus", 0)))
 
-  for i in range(len(wardenSummaries)):
-    wardenSummaries[i]['rank'] = i + 1
+  for i in range(len(warden_summaries)):
+    warden_summaries[i]['rank'] = i + 1
     if ns.pot_size != None:
-      wardenSummaries[i]['payout'] = round(wardenSummaries[i]['payout'], 2)
-      for finding in wardenSummaries[i]['findings']:
+      warden_summaries[i]['payout'] = round(warden_summaries[i]['payout'], 2)
+      for finding in warden_summaries[i]['findings']:
         finding['payout'] = round(finding['payout'], 2)
 
-  return { "totalShares": issueSummary["totalShares"], "payouts": wardenSummaries }
+  return { "totalShares": issue_summary["totalShares"], "payouts": warden_summaries }
 
 def findings(ns):
-  issueSummary = getIssueSummary(ns)
-  h = issueSummary["issueMap"]
+  issue_summary = get_issue_summary(ns)
+  h = issue_summary["issueMap"]
   for id in h:
     if "payoutPerDup" in h[id]:
-      h[id]["payoutPerDup"] = ppUSD(h[id]["payoutPerDup"])
+      h[id]["payoutPerDup"] = pp_usd(h[id]["payoutPerDup"])
   rs = [h[k] for k in h]
   rs.sort(key=lambda r: r["id"])
-  return { "totalShares": issueSummary["totalShares"], "findings": rs }
+  return { "totalShares": issue_summary["totalShares"], "findings": rs }
 
 ns = parser.parse_args(sys.argv[1:])
 

--- a/c4-review/c4-review
+++ b/c4-review/c4-review
@@ -200,11 +200,14 @@ def payout(ns):
 
   for w in ws:
     # gatherer
-    highRiskFindings = sum(f["severity"] == "H" for f in ws[w]["findings"])
-    mediumRiskFindings = sum(f["severity"] == "M" for f in ws[w]["findings"])
-    
-    highScore = 10 * highRiskFindings / totalHighRiskFindings if totalHighRiskFindings else 0
-    mediumScore = 3 * mediumRiskFindings / totalMediumRiskFindings if totalMediumRiskFindings else 0
+    highScore = 0
+    mediumScore = 0
+    for f in ws[w]["findings"]:
+        partialWeighting = f["sliceCredit"] if f["sliceCredit"] < 1 else 1
+        if f["severity"] == "H":
+            highScore += 10 * partialWeighting / totalHighRiskFindings
+        elif f["severity"] == "M":
+            mediumScore += 3 * partialWeighting / totalMediumRiskFindings
     
     gathererScore = highScore + mediumScore
     ws[w]["gathererScore"] = gathererScore
@@ -220,10 +223,11 @@ def payout(ns):
     for f in ws[w]["findings"]:
       if f["dups"] < 5:
         # partial dupes only get partial credit towards the TH/TG scoring
+        partialWeighting = f["sliceCredit"] if f["sliceCredit"] < 1 else 1
         if f["severity"] == "H":
-          wScore += 10 / f["dups"] * (f["sliceCredit"] if f["sliceCredit"] < 1 else 1)
+          wScore += 10 / f["dups"] * partialWeighting
         elif f["severity"] == "M":
-          wScore += 3 / f["dups"] * (f["sliceCredit"] if f["sliceCredit"] < 1 else 1)
+          wScore += 3 / f["dups"] * partialWeighting
 
     ws[w]["hunterScore"] = wScore
     if wScore > hunterBestScore:

--- a/c4-review/c4-review
+++ b/c4-review/c4-review
@@ -192,16 +192,15 @@ def payout(ns):
   # Calculate bonuses
   gatherers, highest_gatherer_score = ([], 0)
   hunters, highest_hunter_score = ([], 0)
-
-  total_high_risk_findings = sum(f["severity"] == "H" for w in ws for f in ws[w]["findings"])
-  total_medium_risk_findings = sum(f["severity"] == "M" for w in ws for f in ws[w]["findings"])
+  num_highs = sum(f["severity"] == "H" for w in ws for f in ws[w]["findings"])
+  num_mediums = sum(f["severity"] == "M" for w in ws for f in ws[w]["findings"])
 
   for w in ws:
     gatherer_score = 0
     hunter_score = 0
     for f in ws[w]["findings"]:
       severity_score = 10 if is_high(f) else 3
-      total_severity_findings = total_high_risk_findings if is_high(f) else total_medium_risk_findings
+      total_severity_findings = num_highs if is_high(f) else num_mediums
       # Partial dupes only get partial credit towards the TH/TG scoring
       partial_weighting = min(f["sliceCredit"], 1)
       gatherer_score += severity_score / total_severity_findings * partial_weighting

--- a/c4-review/c4-review
+++ b/c4-review/c4-review
@@ -114,46 +114,46 @@ def get_issue_summary(ns):
   get_participants_from_gh(repo)
   rs = get_records_from_gh(ns, repo)
 
-  h = {}
+  dup_sets = {}
   for r in rs:
     id = r["reportId"]
-    if not id in h:
-      h[id] = { "id": id, "dups": 0, "leadFinding": "unknown", "handles": [], "severity": r["severity"], "findings": [] }
+    if not id in dup_sets:
+      dup_sets[id] = { "id": id, "dups": 0, "leadFinding": "unknown", "handles": [], "severity": r["severity"], "findings": [] }
     if r["duplicateOf"] == "":
-      h[id]["leadFinding"] = r["handle"]
-      h[id]["githubIssueId"] = r["issueId"]
-    if not r["handle"] in h[id]["handles"]:
-      h[id]["dups"] += 1
-      h[id]["handles"].append(r["handle"])
+      dup_sets[id]["leadFinding"] = r["handle"]
+      dup_sets[id]["githubIssueId"] = r["issueId"]
+    if not r["handle"] in dup_sets[id]["handles"]:
+      dup_sets[id]["dups"] += 1
+      dup_sets[id]["handles"].append(r["handle"])
       # Assumes no warden will get multiple duplicates of the same finding with different partial credit
-      h[id]["findings"].append({ "handle": r["handle"], "percentage": r["percentage"], "issueId": r["issueId"] })
+      dup_sets[id]["findings"].append({ "handle": r["handle"], "percentage": r["percentage"], "issueId": r["issueId"] })
 
   ## Calculate shares
   total_shares = 0.0
-  for key in h:
-    base_shares = 10.0 if is_high(h[key]) else 3.0
-    dups = h[key]["dups"]
-    group_shares = base_shares * BASE**(dups - 1)
+  for id in dup_sets:
+    base_shares = 10 if is_high(dup_sets[id]) else 3
+    group_shares = base_shares * BASE**(dup_sets[id]["dups"] - 1)
 
     total_credit = 0.0
-    for finding in h[key]["findings"]:
-      if finding["handle"] == h[key]["leadFinding"]:
+    for finding in dup_sets[id]["findings"]:
+      if finding["handle"] == dup_sets[id]["leadFinding"]:
         finding["sliceCredit"] = 1.3
       else:
         finding["sliceCredit"] = finding["percentage"] / 100.0
       total_credit += finding["sliceCredit"]
 
-    for finding in h[key]["findings"]:
+    for finding in dup_sets[id]["findings"]:
       finding["shares"] = group_shares * (finding["sliceCredit"] / total_credit)
       total_shares += finding["shares"]
 
   # A pass to calculate fractions and payouts
-  for key in h:
-    for finding in h[key]["findings"]:
+  for id in dup_sets:
+    for finding in dup_sets[id]["findings"]:
       finding["fraction"] = finding["shares"] / total_shares
       if ns.pot_size != None:
         finding["payout"] = finding["fraction"] * ns.pot_size * 0.8 # remove bonuses
-  return { "totalShares": total_shares, "issueMap": h }
+
+  return { "totalShares": total_shares, "issueMap": dup_sets }
 
 def payout(ns):
   issue_summary = get_issue_summary(ns)
@@ -169,6 +169,7 @@ def payout(ns):
         if ns.pot_size != None:
           ws[w]["payout"] = 0.0
         ws[w].update({ "findings": [], "findingsCount": 0, "fraction": 0.0 })
+
       is_lead_finding = h[id]["leadFinding"] == w
       rec = { "findingId": finding["issueId"], "isLeadFinding": is_lead_finding }
       if not is_lead_finding:
@@ -180,6 +181,7 @@ def payout(ns):
         "shares": finding["shares"]
       })
       ws[w]["findings"].append(rec)
+
       ws[w]["fraction"] += finding["fraction"]
       if ns.pot_size != None:
         rec["payout"] = finding["payout"]

--- a/c4-review/c4-review
+++ b/c4-review/c4-review
@@ -192,8 +192,8 @@ def payout(ns):
   # Calculate bonuses
   gatherers, highest_gatherer_score = ([], 0)
   hunters, highest_hunter_score = ([], 0)
-  num_highs = sum(f["severity"] == "H" for w in ws for f in ws[w]["findings"])
-  num_mediums = sum(f["severity"] == "M" for w in ws for f in ws[w]["findings"])
+  num_highs = sum(h[id]["severity"] == "H" for id in h)
+  num_mediums = sum(h[id]["severity"] == "M" for id in h)
 
   for w in ws:
     gatherer_score = 0
@@ -201,7 +201,10 @@ def payout(ns):
     for f in ws[w]["findings"]:
       severity_score = 10 if is_high(f) else 3
       total_severity_findings = num_highs if is_high(f) else num_mediums
-      # Partial dupes only get partial credit towards the TH/TG scoring
+      # Partial dupes either only get partial credit towards the TH/TG scoring
+      # (see https://discord.com/channels/810916927919620096/976603323450941440/1257966110376984658)
+      # or none (https://docs.code4rena.com/awarding/incentive-model-and-awards#bonuses-for-top-competitors)
+      # Going with the first here
       partial_weighting = min(f["sliceCredit"], 1)
       gatherer_score += severity_score / total_severity_findings * partial_weighting
       if f["dups"] < 5:

--- a/c4-review/c4-review
+++ b/c4-review/c4-review
@@ -202,9 +202,8 @@ def payout(ns):
     gathererScore = 0
     hunterScore = 0
     for f in ws[w]["findings"]:
-      isHigh = f["severity"] == "H"
-      severity_score = 10 if isHigh else 3
-      totalSeverityFindings = totalHighRiskFindings if isHigh else totalMediumRiskFindings
+      severity_score = 10 if isHigh(f) else 3
+      totalSeverityFindings = totalHighRiskFindings if isHigh(f) else totalMediumRiskFindings
       # partial dupes only get partial credit towards the TH/TG scoring
       partialWeighting = min(f["sliceCredit"], 1)
       gathererScore += severity_score / totalSeverityFindings * partialWeighting

--- a/c4-review/c4-review
+++ b/c4-review/c4-review
@@ -57,7 +57,6 @@ def get_records_from_gh(ns, repo):
     if 'unsatisfactory' in [label.name for label in i.labels]:
       unsatisfactory_issues.add(str(i.number))
 
-  # headers = ["reportId", "duplicateOf", "score", "risk", "handle", "title", "issueId", "issueUrl", "gh_Risk", "gh_isOpen", "gh_isDuplicate", "gh_isInvalid"]
   for i in issues:
     duplicateOf = ""
     issueId = str(i.number)
@@ -78,6 +77,8 @@ def get_records_from_gh(ns, repo):
         severity = "H"
       elif l.name in ['unsatisfactory', 'withdrawn by warden']:
         skip = True
+      elif l.name.startswith("partial-"):
+        percentage = int(l.name.split("-")[1])
 
     if skip or severity is None:
       continue
@@ -118,32 +119,42 @@ def getIssueSummary(ns):
   h = {}
   for r in rs:
     id=r["reportId"]
-    # if id in disputed_reports:
-    #   continue
     if not id in h:
-      h[id] = { "id": id, "dups": 0, "leadFinding": "unknown", "handles": [], "severity": r["severity"], "percentage": r["percentage"] }
+      h[id] = { "id": id, "dups": 0, "leadFinding": "unknown", "handles": [], "severity": r["severity"], "findings": [] }
     if r["duplicateOf"] == "":
       h[id]["leadFinding"] = r["handle"]
       h[id]["githubIssueId"] = r["issueId"]
     if not r["handle"] in h[id]["handles"]:
       h[id]["dups"] += 1
       h[id]["handles"].append(r["handle"])
+      # assumes no warden will get both a full credit and partial credit duplicate of the same finding
+      h[id]["findings"].append({"handle": r["handle"], "percentage": r["percentage"], "issueId": r["issueId"]})
 
   ## Calculate shares
   totalShares = 0.0
   for key in h:
     baseShares = 10.0 if isHigh(h[key]) else 3.0
     dups = h[key]["dups"]
-    h[key]["sharesForIssue"] = baseShares * BASE**(dups - 1)
-    h[key]["sharesPerDup"] = h[key]["sharesForIssue"] / dups
-    # also include the 30% bonus to the finding selected for report
-    totalShares += h[key]["sharesForIssue"] + h[key]["sharesPerDup"] * 0.3
+    groupShares = baseShares * BASE**(dups - 1)
+
+    totalCredit = 0.0
+    for finding in h[key]["findings"]:
+      if finding["handle"] == h[key]["leadFinding"]:
+        finding["sliceCredit"] = 1.3
+      else:
+        finding["sliceCredit"] = finding["percentage"] / 100.0
+      totalCredit += finding["sliceCredit"]
+
+    for finding in h[key]["findings"]:
+      finding["shares"] = groupShares * (finding["sliceCredit"] / totalCredit)
+      totalShares += finding["shares"]
 
   # A pass to calculate fractions and payouts
   for key in h:
-    h[key]["fractionPerDup"] = h[key]["sharesPerDup"] / totalShares
-    if ns.pot_size != None:
-      h[key]["payoutPerDup"] = h[key]["fractionPerDup"] * ns.pot_size * 0.8 # remove bonuses
+    for finding in h[key]["findings"]:
+      finding["fraction"] = finding["shares"] / totalShares
+      if ns.pot_size != None:
+        finding["payout"] = finding["fraction"] * ns.pot_size * 0.8 # remove bonuses
   return { "totalShares": totalShares, "issueMap": h }
 
 def payout(ns):
@@ -153,34 +164,32 @@ def payout(ns):
   # Summarise results for each handle
   ws = {}
   for id in h:
-    # if id == "529" or h[id]["leadFinding"] == "529":
-    #   continue
-    for w in h[id]["handles"]:
+    for finding in h[id]["findings"]:
+      w = finding["handle"]
       if not w in ws:
-        ws[w] = { "handle": w, "findings": [], "fraction": 0.0 }
+        ws[w] = { "rank": 0, "handle": w }
         if ns.pot_size != None:
-          ws[w]["payout"] = 0.0
+          ws[w]["payout"] = 0
+        ws[w].update({ "findings": [], "findingsCount": 0, "fraction": 0.0 })
       isLeadFinding = h[id]["leadFinding"] == w
-      rec = { "id": id, "dups": h[id]["dups"], "sharesPerDup": h[id]["sharesPerDup"], "fractionPerDup": h[id]["fractionPerDup"], "isLeadFinding": isLeadFinding, "severity": h[id]["severity"] }
-      if ns.pot_size != None:
-        rec["payoutPerDup"] = h[id]["payoutPerDup"]
+      rec = { "findingId": finding["issueId"], "isLeadFinding": isLeadFinding }
+      if not isLeadFinding:
+        rec["leadFindingId"] = h[id]["githubIssueId"]
+      rec.update({
+          "severity": h[id]["severity"],
+          "dups": h[id]["dups"],
+          "sliceCredit": finding["sliceCredit"],
+          "shares": finding["shares"]
+      })
       ws[w]["findings"].append(rec)
-
-      factor = h[id]["percentage"] / 100.0
-      if isLeadFinding:
-        factor = 1.3 # 30% shares bonus
-
-      ws[w]["fraction"] += h[id]["fractionPerDup"] * factor
+      ws[w]["fraction"] += finding["fraction"]
       if ns.pot_size != None:
-        ws[w]["payout"] += h[id]["payoutPerDup"] * factor
+        rec["payout"] = finding["payout"]
+        ws[w]["payout"] += finding["payout"]
 
   for w in ws:
       ws[w]["findingsCount"] = len(ws[w]["findings"])
-
-  if ns.pot_size != None:
-    for w in ws:
-      ws[w]["payout"]
-      ws[w]["findings"].sort(key=lambda r: r["id"])
+      ws[w]["findings"].sort(key=lambda r: -r["shares"])
 
   # bonuses
   gatherers, highestGathererScore = ([], 0)
@@ -206,13 +215,15 @@ def payout(ns):
     elif gathererScore == highestGathererScore:
       gatherers.append(w)
 
+    # hunter
     wScore = 0
     for f in ws[w]["findings"]:
-      if f["dups"] < 5:  # Only count findings with fewer than 5 submissions
+      if f["dups"] < 5:
+        # partial dupes only get partial credit towards the TH/TG scoring
         if f["severity"] == "H":
-          wScore += 10 * (1 / f["dups"])
+          wScore += 10 / f["dups"] * (f["sliceCredit"] if f["sliceCredit"] < 1 else 1)
         elif f["severity"] == "M":
-          wScore += 3 * (1 / f["dups"])
+          wScore += 3 / f["dups"] * (f["sliceCredit"] if f["sliceCredit"] < 1 else 1)
 
     ws[w]["hunterScore"] = wScore
     if wScore > hunterBestScore:
@@ -221,20 +232,32 @@ def payout(ns):
     elif wScore == hunterBestScore:
       hunters.append(w)
 
-  bonus = ns.pot_size * 0.1
-  for hunter in hunters:
-    ws[hunter]["payout"] += bonus / len(hunters)
-    ws[hunter]["hunterBonus"] = bonus / len(hunters)
-
-  for gatherer in gatherers:
-    ws[gatherer]["payout"] += bonus / len(gatherers)
-    ws[gatherer]["gathererBonus"] = bonus / len(gatherers)
+  bonus = 0.1 if ns.pot_size is None else ns.pot_size * 0.1
+  for role, winners in [("hunter", hunters), ("gatherer", gatherers)]:
+    for winner in winners:
+      ws[winner][f"{role}Bonus"] = bonus / len(winners)
+      if ns.pot_size is not None:
+        ws[winner]["payout"] += bonus / len(winners)
 
   wardenSummaries = [ws[w] for w in ws if (lambda w: ns.handle == None or w == ns.handle)(w)]
-  wardenSummaries.sort(key=lambda r: -r["payout"])
+  if ns.pot_size is not None:
+    wardenSummaries.sort(key=lambda r: -r["payout"])
+  else: # should be the same
+    wardenSummaries.sort(key=lambda r: -(r.get("fraction", 0) * 0.8 + r.get("hunterBonus", 0) + r.get("gathererBonus", 0)))
 
   for i in range(len(wardenSummaries)):
     wardenSummaries[i]['rank'] = i + 1
+
+    if ns.pot_size != None:
+      # Round payouts
+      wardenSummaries[i]['payout'] = round(wardenSummaries[i]['payout'], 2)
+      if 'hunterBonus' in wardenSummaries[i]:
+        wardenSummaries[i]['hunterBonus'] = round(wardenSummaries[i]['hunterBonus'], 2)
+      if 'gathererBonus' in wardenSummaries[i]:
+        wardenSummaries[i]['gathererBonus'] = round(wardenSummaries[i]['gathererBonus'], 2)
+      
+      for finding in wardenSummaries[i]['findings']:
+        finding['payout'] = round(finding['payout'], 2)
 
   rs = { "totalShares": issueSummary["totalShares"], "payouts": wardenSummaries }
   return rs

--- a/c4-review/c4-review
+++ b/c4-review/c4-review
@@ -23,7 +23,7 @@ parser = argparse.ArgumentParser(prog="c4-review", formatter_class=argparse.RawT
                                  description="Analyzes the GitHub findings repo and provides stats. Estimates payout if you provide a handle")
 subp = parser.add_subparsers(dest="command") # dest="command" means that we see which command was parsed
 
-base_help = f"Change base (default {BASE}) for Sybil protection"
+base_help = f"Change base (default {BASE}) for Sybil protection e.g. --base=0.9 (for old comps)"
 
 payout = subp.add_parser("payouts", description="Find out the fraction of total pot or payouts")
 payout.add_argument('findings_repo', type=str)

--- a/c4-review/c4-review
+++ b/c4-review/c4-review
@@ -73,7 +73,7 @@ def get_records_from_gh(ns, repo):
         severity = "M"
       elif l.name == "3 (High Risk)":
         severity = "H"
-      elif l.name in ['unsatisfactory', 'withdrawn by warden']:
+      elif l.name in ['unsatisfactory', 'withdrawn by warden', 'nullified']:
         skip = True
       elif l.name.startswith("partial-"):
         percentage = int(l.name.split("-")[1])

--- a/c4-review/c4-review
+++ b/c4-review/c4-review
@@ -23,7 +23,7 @@ parser = argparse.ArgumentParser(prog="c4-review", formatter_class=argparse.RawT
                                   description="Analyzes the GitHub findings repo and provides stats. Estimates payout if you provide a handle")
 subp = parser.add_subparsers(dest="command") # dest="command" means that we see which command was parsed
 
-base_help = f"Change base (default {BASE}) for Sybil protection e.g. --base=0.9 (for old comps)"
+base_help = f"Change base (default {BASE}) for Sybil protection"
 
 payout = subp.add_parser("payouts", description="Find out the fraction of total pot or payouts")
 payout.add_argument('findings_repo', type=str)
@@ -193,47 +193,36 @@ def payout(ns):
 
   # bonuses
   gatherers, highestGathererScore = ([], 0)
-  hunters, hunterBestScore = ([], 0)
+  hunters, highestHunterScore = ([], 0)
 
   totalHighRiskFindings = sum(f["severity"] == "H" for w in ws for f in ws[w]["findings"])
   totalMediumRiskFindings = sum(f["severity"] == "M" for w in ws for f in ws[w]["findings"])
 
   for w in ws:
-    # gatherer
-    highScore = 0
-    mediumScore = 0
+    gathererScore = 0
+    hunterScore = 0
     for f in ws[w]["findings"]:
-        partialWeighting = f["sliceCredit"] if f["sliceCredit"] < 1 else 1
-        if f["severity"] == "H":
-            highScore += 10 * partialWeighting / totalHighRiskFindings
-        elif f["severity"] == "M":
-            mediumScore += 3 * partialWeighting / totalMediumRiskFindings
-    
-    gathererScore = highScore + mediumScore
-    ws[w]["gathererScore"] = gathererScore
+      isHigh = f["severity"] == "H"
+      severity_score = 10 if isHigh else 3
+      totalSeverityFindings = totalHighRiskFindings if isHigh else totalMediumRiskFindings
+      # partial dupes only get partial credit towards the TH/TG scoring
+      partialWeighting = min(f["sliceCredit"], 1)
+      gathererScore += severity_score / totalSeverityFindings * partialWeighting
+      if f["dups"] < 5:
+        hunterScore += severity_score / f["dups"] * partialWeighting
 
+    ws[w]["gathererScore"] = gathererScore
     if gathererScore > highestGathererScore:
       highestGathererScore = gathererScore
       gatherers = [w]
     elif gathererScore == highestGathererScore:
       gatherers.append(w)
 
-    # hunter
-    wScore = 0
-    for f in ws[w]["findings"]:
-      if f["dups"] < 5:
-        # partial dupes only get partial credit towards the TH/TG scoring
-        partialWeighting = f["sliceCredit"] if f["sliceCredit"] < 1 else 1
-        if f["severity"] == "H":
-          wScore += 10 / f["dups"] * partialWeighting
-        elif f["severity"] == "M":
-          wScore += 3 / f["dups"] * partialWeighting
-
-    ws[w]["hunterScore"] = wScore
-    if wScore > hunterBestScore:
-      hunterBestScore = wScore
+    ws[w]["hunterScore"] = hunterScore
+    if hunterScore > highestHunterScore:
+      highestHunterScore = hunterScore
       hunters = [w]
-    elif wScore == hunterBestScore:
+    elif hunterScore == highestHunterScore:
       hunters.append(w)
 
   bonus = 0.1 if ns.pot_size is None else ns.pot_size * 0.1
@@ -299,8 +288,8 @@ else:
   parser.parse_args(["--help"])
 
 
-result["note"] = ("This tool only calculates shares for Highs and Mediums and will overestimate " +
-                    "a little. It does not take into account QA reports.")
+result["note"] = ("This tool only calculates shares for Highs and Mediums. " +
+                    "It does not take into account QA reports.")
 
 ## Prints the records as valid JSON
 print(json.dumps(result, indent=2))


### PR DESCRIPTION
Computer says:

1. Implemented partial credit scoring:
   - Added support for "partial-" labels to determine percentage credit for findings.
   - Updated the share calculation to account for partial credits.

2. Improved bonus calculation:
   - Implemented a more detailed calculation for hunter and gatherer bonuses.
   - Added partial credit consideration in the hunter score calculation. (good bot - now also for gatherer)

3. Enhanced output format:
   - Improved sorting of findings and wardens.
   - Added more detailed information to the output, including lead findings and issue IDs.
   - Implemented rounding for payouts and bonuses.

4. Minor fixes and optimizations:
   - Removed commented-out code and unused variables.
   - Improved handling of cases where pot size is not provided.