### PR TITLE
Fix selected for report bonus not being calculated on top

### DIFF
--- a/c4-review/c4-review
+++ b/c4-review/c4-review
@@ -132,8 +132,9 @@ def get_issue_summary(ns):
   ## Calculate shares
   total_shares = 0.0
   for id in dup_sets:
+    num_dups = dup_sets[id]["dups"]
     base_shares = 10 if is_high(dup_sets[id]) else 3
-    group_shares = base_shares * BASE**(dup_sets[id]["dups"] - 1)
+    group_shares = base_shares * BASE**(num_dups - 1) * (num_dups + 0.3) / num_dups # including 30% selected for report bonus
 
     total_credit = 0.0
     for finding in dup_sets[id]["findings"]:

--- a/c4-review/c4-review
+++ b/c4-review/c4-review
@@ -173,15 +173,14 @@ def payout(ns):
         ws[w].update({ "findings": [], "findingsCount": 0, "fraction": 0.0 })
 
       is_lead_finding = h[id]["leadFinding"] == w
-      rec = { "findingId": finding["issueId"], "isLeadFinding": is_lead_finding }
-      if not is_lead_finding:
-        rec["leadFindingId"] = h[id]["githubIssueId"]
-      rec.update({
+      rec = { "findingId": finding["issueId"],
+        "isLeadFinding": is_lead_finding,
+        "leadFindingId" : h[id]["githubIssueId"],
         "severity": h[id]["severity"],
         "dups": h[id]["dups"],
         "sliceCredit": finding["sliceCredit"],
         "shares": finding["shares"]
-      })
+      }
       ws[w]["findings"].append(rec)
 
       ws[w]["fraction"] += finding["fraction"]

--- a/c4-review/c4-review
+++ b/c4-review/c4-review
@@ -73,7 +73,8 @@ def get_records_from_gh(ns, repo):
         severity = "M"
       elif l.name == "3 (High Risk)":
         severity = "H"
-      elif l.name in ['unsatisfactory', 'withdrawn by warden', 'nullified', 'ineligible for award']:
+      elif l.name in ['unsatisfactory', 'withdrawn by warden', 'withdrawn by judge',
+                      'nullified', 'ineligible for award']:
         skip = True
       elif l.name.startswith("partial-"):
         percentage = int(l.name.split("-")[1])


### PR DESCRIPTION
Due to the way partial credit was implemented, the 30% was not being calculated on top of the pie but as part of it. This fixes it.

Docs are quite confusing here but I think this is how it's supposed to work https://docs.code4rena.com/awarding/incentive-model-and-awards#duplicates-getting-partial-credit