### PR TITLE
c4-review: dedup per participant, update submissions API handling, minor fixes

### DIFF
--- a/c4-review/c4-review
+++ b/c4-review/c4-review
@@ -263,12 +263,41 @@ def payout(ns):
     if validity != "valid" or severity not in ["high", "medium"]:
       continue
 
-    for submission in finding["submissions"]['data']:
-      credit = get_credit(submission)
+    # Deduplicate submissions per participant (team or user) by max would-be sliceCredit
+    # Build candidate list with computed would-be sliceCredit
+    candidates = []
+    for sub in finding["submissions"]["data"]:
+      credit = get_credit(sub)
       if credit == 0:
         continue
+      is_lead = bool(sub.get("isPrimary", False))
+      slice_candidate = 1.3 if is_lead else credit
+      # Participant key (team preferred)
+      w = (sub.get("user") or {}).get("handle")
+      team = sub.get("team")
+      if team is not None:
+        members = ", ".join(sorted(m.get("handle") for m in team.get("members", []) if m and m.get("handle")))
+        w = f"{team.get('handle')} ({members})"
+      candidates.append({
+        "sub": sub,
+        "credit": credit,
+        "isLead": is_lead,
+        "sliceCandidate": slice_candidate,
+        "participant": w,
+      })
 
-      num_dups += credit
+    # Keep max sliceCandidate per participant
+    best_by_participant = {}
+    for c in candidates:
+      p = c["participant"]
+      if p not in best_by_participant or c["sliceCandidate"] > best_by_participant[p]["sliceCandidate"]:
+        best_by_participant[p] = c
+
+    deduped = list(best_by_participant.values())
+
+    # Compute duplicate count based on deduped set (sum of credits; lead bonus handled later)
+    for c in deduped:
+      num_dups += c["credit"]
 
     if num_dups == 0:
       continue
@@ -277,42 +306,40 @@ def payout(ns):
     finding["shares"] = base_shares * BASE**(num_dups - 1) / num_dups
     finding["dups"] = num_dups
     total_shares += finding["shares"] * (num_dups + 0.3)
+    # Persist deduped candidates for later use when emitting records
+    finding["_deduped"] = deduped
 
   # Summarise results for each handle
   for finding in findings:
     if "shares" not in finding:
       continue
 
-    for idx, submission in enumerate(finding["submissions"]['data']):
-      credit = get_credit(submission)
-      if credit == 0:
-        continue
+    # Use previously computed per-participant deduped list
+    deduped = list(finding.get("_deduped") or [])
+    # Sort: lead first, then by shares contribution
+    deduped.sort(key=lambda c: (not c["isLead"], -c["sliceCandidate"], c["sub"].get("number") or 0))
 
-      if idx == 0:
-        submission["sliceCredit"] = 1.3
-      else:
-        submission["sliceCredit"] = credit
-
+    for idx, c in enumerate(deduped):
+      submission = c["sub"]
+      credit = c["credit"]
+      submission["sliceCredit"] = 1.3 if idx == 0 and c["isLead"] else credit
       submission["shares"] = finding["shares"] * submission["sliceCredit"]
 
-      w = submission["user"]["handle"]
-      if submission["team"] != None:
-        w = f"{submission['team']['handle']} ({', '.join(sorted(m['handle'] for m in submission['team']['members']))})"
+      w = c["participant"]
       if not w in ws:
         ws[w] = { "rank": 0, "handle": w }
         if ns.pot_size != None:
           ws[w]["payout"] = 0.0
-        ws[w].update({ "findings": [], "findingsCount": 0, "fraction": 0.0 })
+        ws[w].update({ "findings": [], "findingsCount": 0 })
 
-      rec = { 
-        "submissionId" : "S-" + str(submission["number"]),
-        "findingId": "F-" + str(finding["number"]),
-        "leadFindingId": "F-" + str(finding["number"]),
-        "isLeadSubmission": idx == 0,
+      rec = {
+        "submissionId": "S-" + str(submission.get("number")),
+        "findingId": "F-" + str(finding.get("number")),
+        "isLeadSubmission": bool(c["isLead"]) and idx == 0,
         "severity": finding["severity"],
         "dups": finding["dups"],
         "sliceCredit": submission["sliceCredit"],
-        "shares": submission["shares"]
+        "shares": submission["shares"],
       }
       ws[w]["findings"].append(rec)
 
@@ -324,11 +351,16 @@ def payout(ns):
     ws[w]["findingsCount"] = len(ws[w]["findings"])
     ws[w]["findings"].sort(key=lambda r: -r["shares"]) 
 
+  # Compute fractions (share of total) for non-payout ranking and for reference
+  if total_shares > 0:
+    for w in ws:
+      ws[w]["fraction"] = sum(rec.get("shares", 0) for rec in ws[w]["findings"]) / total_shares
+
   # Build duplicate sets per finding to compute effective duplicate counts (sum of sliceCredits)
   dup_sets = {}
   for w in ws:
     for rec in ws[w]["findings"]:
-      fid = rec.get("leadFindingId") or rec.get("findingId")
+      fid = rec.get("findingId")
       if fid not in dup_sets:
         dup_sets[fid] = { "findings": [] }
       dup_sets[fid]["findings"].append(rec)
@@ -350,7 +382,7 @@ def payout(ns):
       if f["sliceCredit"] >= 1:
         gatherer_score += severity_score / total_severity_findings
         # Calculate effective number of duplicates including partial credits, remove lead bonus (0.3)
-        fid = f.get("leadFindingId") or f.get("findingId")
+        fid = f.get("findingId")
         group = dup_sets.get(fid, {"findings": []})["findings"]
         effective_dups = sum(d.get("sliceCredit", 0) for d in group) - 0.3
         if effective_dups < 5:
@@ -390,6 +422,14 @@ def payout(ns):
       warden_summaries[i]['payout'] = round(warden_summaries[i]['payout'], 2)
       for finding in warden_summaries[i]['findings']:
         finding['payout'] = round(finding['payout'], 2)
+    # Round floats in findings to avoid precision artifacts in output
+    for finding in warden_summaries[i]['findings']:
+      if 'shares' in finding:
+        finding['shares'] = round(finding['shares'], 6)
+      if 'sliceCredit' in finding:
+        finding['sliceCredit'] = round(finding['sliceCredit'], 6)
+      if 'dups' in finding:
+        finding['dups'] = round(finding['dups'], 6)
 
   return { "totalShares": total_shares, "payouts": warden_summaries }
 


### PR DESCRIPTION
- **c4-review**: dedup submissions per participant; simplify duplicate logic; remove `leadFindingId`; round float outputs; update submissions endpoint + error handling  
- **CLI/Docs**: remove unused `--ignore_disputed` flag; update `README.md` examples/help output